### PR TITLE
WIP helper function to remove a package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: drat
 Type: Package
 Title: 'Drat' R Archive Template
-Version: 0.1.4
-Date: 2017-12-16
+Version: 0.1.4.1
+Date: 2018-03-12
 Author: Dirk Eddelbuettel with contributions by Carl Boettiger, Neal Fultz,
  Sebastian Gibb, Colin Gillespie, Jan Górecki, Matt Jones, Thomas Leeper,
  Steven Pav and Jan Schulz. 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,5 +3,6 @@ importFrom(utils, "untar", "unzip")
 export(addRepo,
        initRepo,
        insertPackage,
+       removePackage,
        pruneRepo,
        archivePackages)

--- a/R/addRepo.R
+++ b/R/addRepo.R
@@ -5,10 +5,11 @@
 ##' repositories.  This function aids in the process, and defaults to
 ##' adding a \sQuote{drat} archive at GitHub under the given account.
 ##'
-##' This function retrieves the current set of repositories and adds
+##' This function retrieves the current set of repositories (see
+##' \code{getOption("repos") for the current values) and adds
 ##' (or overwrites) the entry for the given \sQuote{account}. For
 ##' non-GitHub repositories an alternative URL can be specified as
-##' \sQuote{alturl} (and assigned to \sQuote{account}.
+##' \sQuote{alturl} (and assigned to \sQuote{account} as well).
 ##'
 ##'
 ##' An aliased function \code{add} is also available, but not exported

--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -116,11 +116,11 @@ insertPackage <- function(file,
     if (commit) {
         if (haspkg) {
             repo <- git2r::repository(repodir)
-            setwd(repodir)
-            git2r::add(repo, file.path(reldir, pkg))
-            git2r::add(repo, file.path(reldir, "PACKAGES"))
-            git2r::add(repo, file.path(reldir, "PACKAGES.gz"))
-            git2r::add(repo, file.path(reldir, "PACKAGES.rds"))
+            setwd(pkgdir)
+            git2r::add(repo, pkg)
+            git2r::add(repo, "PACKAGES")
+            git2r::add(repo, "PACKAGES.gz")
+            git2r::add(repo, "PACKAGES.rds")
             tryCatch(git2r::commit(repo, msg), error = function(e) warning(e))
             #TODO: authentication woes?   git2r::push(repo)
             message("Added and committed ", pkg, " plus PACKAGES files. Still need to push.\n")

--- a/R/removePackage.R
+++ b/R/removePackage.R
@@ -61,7 +61,8 @@ removePackage <- function(file,
   }
   
   pkgtype <- identifyPackageType(file)
-  
+  file.remove(file)
+  write_PACKAGES(pkgdir, type=pkgtype, ...)  
 
   ## update index
   
@@ -69,20 +70,17 @@ removePackage <- function(file,
     if (haspkg) {
       repo <- git2r::repository(pkgdir, discover=TRUE)
       setwd(pkgdir)
-      git2r::rm_file(repo, sub(workdir(repo), "", file))
-      write_PACKAGES(pkgdir, type=pkgtype, ...)
+      git2r::add(repo, sub(git2r::workdir(repo), "", file))
       git2r::add(repo, "PACKAGES")
       git2r::add(repo, "PACKAGES.gz")
       git2r::add(repo, "PACKAGES.rds")
       tryCatch({
         git2r::commit(repo, msg)
         #TODO: authentication woes?   git2r::push(repo)
-        message("Added and committed ", pkg, " plus PACKAGES files. Still need to push.\n")
+        message("Removed and committed ", pkg, " plus PACKAGES files. Still need to push.\n")
         }, error = function(e) warning(e))
     } else if (hascmd) {
       setwd(pkgdir)
-      file.remove(file)
-      write_PACKAGES(pkgdir, type=pkgtype, ...)
       pkgfs <- "PACKAGES PACKAGES.gz PACKAGES.rds"
       cmd <- sprintf(paste("git add %s;",
                            "git add %s;",
@@ -94,10 +92,7 @@ removePackage <- function(file,
       warning("Commit skipped as both git2r package and git command missing.",
               call.=FALSE)
     }
-  } else {
-    file.remove(file)
-    write_PACKAGES(pkgdir, type=pkgtype, ...)
-  }
+  } 
   
   invisible(NULL)
 }

--- a/R/removePackage.R
+++ b/R/removePackage.R
@@ -1,0 +1,104 @@
+##' @title Remove a package source or binary file into a drat repository
+##' @aliases drat:::remove
+##' @param file An R package in source or binary format,
+##' @param repodir A local directory corresponding to the repository
+##' top-level directory.
+##' @param commit Either boolean toggle to select automatic git operations
+##' \sQuote{add}, \sQuote{commit}, and \sQuote{push} or, alternatively,
+##' a character variable can be used to specify a commit message; this also
+##' implies the \sQuote{TRUE} values in other contexts.
+##' @param pullfirst Boolean toggle to call \code{git pull} before removing the package.
+##' @param action A character string containing one of: \dQuote{none}
+##' (the default; add the new package into the repo, effectively masking
+##' previous versions), \dQuote{archive} (place any previous versions into
+##' a package-specific archive folder, creating such an archive if it does
+##' not already exist), or \dQuote{prune} (calling \code{\link{pruneRepo}}).
+##' @param ... For \code{insert} the aliases variant, a catch-all collection of
+##' parameters. For \code{insertPackage} arguments passed to \code{write_PACKAGES}.
+##' @return NULL is returned.
+##' @examples
+##' \dontrun{
+##'   removePackage("foo_0.2.3.tar.gz")   # Removes foo_0.2.3.tar.gz from repo in cwd
+##' }
+##' @author Dirk Eddelbuettel, Neal Fultz
+removePackage <- function(file,
+                          commit=FALSE,
+                          pullfirst=FALSE,
+                          ...) {
+  
+  if (!file.exists(file)) stop("File ", file, " not found\n", call.=FALSE)
+  
+  ## check for the optional git2r package
+  haspkg <- requireNamespace("git2r", quietly=TRUE)
+  hascmd <- length(Sys.which("git")) > 0
+  
+  curwd <- getwd()
+  on.exit(setwd(curwd))               # restore current working directory
+  
+  file <- normalizePath(file, mustWork = TRUE) # Error if result cannot be determinded
+  pkg <- basename(file)
+  pkgdir <- dirname(file)
+  setwd(pkgdir)
+  
+  
+  msg <- if (isTRUE(commit)) sprintf("Removing %s from drat", pkg) else ""
+  ## special case of commit via message: not TRUE, and character
+  if (!isTRUE(commit) && typeof(commit) == "character" && nchar(commit) > 0) {
+    msg <- commit
+    commit <- TRUE
+  }
+  
+  branch <- getOption("dratBranch", "gh-pages")
+  if (commit && haspkg) {
+    repo <- git2r::repository(pkgdir, discover=TRUE)
+    if (isTRUE(pullfirst)) git2r::pull(repo)
+    git2r::checkout(repo, branch)
+  } else if (commit && hascmd) {
+    setwd(pkgdir)
+    if (isTRUE(pullfirst)) system("git pull")
+    system2("git", c("checkout", branch))
+    setwd(curwd)
+  }
+  
+  pkgtype <- identifyPackageType(file)
+  
+  file.remove(file)
+
+  ## update index
+  write_PACKAGES(pkgdir, type=pkgtype, ...)
+  
+  if (commit) {
+    if (haspkg) {
+      repo <- git2r::repository(repodir)
+      setwd(pkgdir)
+      git2r::rm_file(repo, pkg)
+      git2r::add(repo, "PACKAGES")
+      git2r::add(repo, "PACKAGES.gz")
+      git2r::add(repo, "PACKAGES.rds")
+      tryCatch(git2r::commit(repo, msg), error = function(e) warning(e))
+      #TODO: authentication woes?   git2r::push(repo)
+      message("Added and committed ", pkg, " plus PACKAGES files. Still need to push.\n")
+    } else if (hascmd) {
+      setwd(pkgdir)
+      pkgfs <- "PACKAGES PACKAGES.gz PACKAGES.rds"
+      cmd <- sprintf(paste("git rm %s;",
+                           "git add %s;",
+                           "git commit -m\"%s\";",
+                           "git push"), pkg, pkgfs, msg)
+      system(cmd) ## TODO: error checking
+      message("Removed, committed and pushed ", pkg, " plus PACKAGES files.\n")
+    } else {
+      warning("Commit skipped as both git2r package and git command missing.",
+              call.=FALSE)
+    }
+  }
+  
+  invisible(NULL)
+}
+
+
+
+##' @rdname insertPackage
+remove <- removePackage
+
+

--- a/tests/skeleton_git2r.R
+++ b/tests/skeleton_git2r.R
@@ -35,8 +35,13 @@ testSkeletonGit2r <- function() {
   git2r::branch_create(comm,"gh-pages")
 
   # finally add the package
-  drat::insertPackage(file = file.path(wd, "foo_1.0.tar.gz"), repodir = rdir, commit = "test")
+  drat::insertPackage(file = file.path(wd, "foo_1.0.tar.gz"), repodir = rdir, commit = "test add")
   list(git2r::status(repo), dir(rdir, recursive = TRUE))
+
+  drat:::removePackage(file = file.path(rdir, "src", "contrib", "foo_1.0.tar.gz"), commit = "test remove")
+  list(git2r::status(repo), dir(rdir, recursive = TRUE))
+  
+  setwd(cwd)
 }
 
 testSkeletonGit2r()

--- a/tests/skeleton_git2r.R
+++ b/tests/skeleton_git2r.R
@@ -1,0 +1,39 @@
+
+testSkeletonGit2r <- function() {
+  if(!requireNamespace("git2r")) return(warning("couldn't find git2r"))
+  
+  wd <- tempdir()
+  
+  # options(error=traceback)
+  
+  # make a package to test with
+  .foofn <- function() "foo"
+  utils::package.skeleton(name = "foo", list=".foofn", environment = environment(), path=wd)
+  print(dir(wd, recursive = TRUE))
+
+  message("building")
+  
+  #https://github.com/r-lib/testthat/issues/129
+  R_TESTS=Sys.getenv("R_TESTS")
+  Sys.setenv(R_TESTS="")
+  system(sprintf("R CMD build %s --no-manual", file.path(wd, "foo")))
+  Sys.setenv(R_TESTS=R_TESTS)
+  message("dratting")
+  
+  # make a repo to test with
+  rdir <- file.path(wd, "drat")
+  
+  dir.create(rdir)
+  repo <- git2r::init(rdir)
+  git2r::config(repo, user.name="Alice", user.email="alice@example.org")
+  cat("foo", file=file.path(rdir, "README"))
+  git2r::add(repo, "README")
+  comm <- git2r::commit(repo, "init")
+  git2r::branch_create(comm,"gh-pages")
+
+  # finally add the package
+  drat::insertPackage(file = "foo_1.0.tar.gz", repodir = rdir, commit = "test")
+  list(git2r::status(repo), dir(rdir, recursive = TRUE))
+}
+
+testSkeletonGit2r()

--- a/tests/skeleton_git2r.R
+++ b/tests/skeleton_git2r.R
@@ -16,7 +16,10 @@ testSkeletonGit2r <- function() {
   #https://github.com/r-lib/testthat/issues/129
   R_TESTS=Sys.getenv("R_TESTS")
   Sys.setenv(R_TESTS="")
-  system(sprintf("R CMD build %s --no-manual", file.path(wd, "foo")))
+  cwd <- getwd()
+  setwd(wd)
+  system("R CMD build foo --no-manual")
+  setwd(cwd)
   Sys.setenv(R_TESTS=R_TESTS)
   message("dratting")
   
@@ -32,7 +35,7 @@ testSkeletonGit2r <- function() {
   git2r::branch_create(comm,"gh-pages")
 
   # finally add the package
-  drat::insertPackage(file = "foo_1.0.tar.gz", repodir = rdir, commit = "test")
+  drat::insertPackage(file = file.path(wd, "foo_1.0.tar.gz"), repodir = rdir, commit = "test")
   list(git2r::status(repo), dir(rdir, recursive = TRUE))
 }
 


### PR DESCRIPTION
I wanted this function because I've had to host my own builds for published packages, it seems like mac-oldrel is not getting updated by cran these days.  

This is very rough, not ready to merge yet, still needs the following.

  - [ ] Pull out common logic from insert package into helpers
  - [ ] fix documentation
  - [ ] test for commit=FALSE
  - [ ] test for commit=TRUE, cli backend
  - [ ] test for commit=TRUE, git2r backend